### PR TITLE
feat: add styles to messages boxes

### DIFF
--- a/src/Views/Private/Chat/Chat.vue
+++ b/src/Views/Private/Chat/Chat.vue
@@ -27,14 +27,17 @@ export default defineComponent({
 			messages: [
 				{
 					id: 1,
-					content: 'Somos niggas',
+					content:
+						'Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industrys \
+							standard dummy text ever since the 1500s, when an unknown printer took a galley of type and \
+							scrambled it to make a type specimen book.',
 					sendAt: new Date(),
 					recipient: 13,
 					sender: 12,
 				},
 				{
 					id: 2,
-					content: 'Somos negs',
+					content: 'ojhashudhiasd',
 					sendAt: new Date(),
 					recipient: 12,
 					sender: 13,

--- a/src/Views/Private/Chat/components/Messages/Messages.scss
+++ b/src/Views/Private/Chat/components/Messages/Messages.scss
@@ -1,30 +1,39 @@
 .message{
     &__wrapper{
+
+        margin: 2.5rem;
+
         &--sender{
-            background-color: var(--color-primary);
-            border-radius: 1rem;
+            max-width: 65%;
+            margin-left: auto;
             display: flex;
-            padding: 0.5rem;
-            margin: 2.5rem 1.5rem 2.5rem auto;
-            flex-direction: row-reverse;
-            max-width: calc(100% - 55%);
-            overflow-wrap: break-word;
-        }
-        &--sender span {
-            padding: 0.7rem;
+            flex-direction: column;
+            align-items: end;
+            margin-block: 2rem;
+            
+            &-content{
+                background-color: var(--color-primary);
+                border-radius: 1rem;
+                text-align: end;
+                padding: 1.2rem;
+                width: fit-content; 
+            }
+
         }
 
         &--recipient{
-            background-color: var(--color-secondary);
-            border-radius: 1rem;
+            max-width: 65%;
             display: flex;
-            padding: 0.5rem;
-            margin: 2.5rem auto 2.5rem 1.5rem;
-            max-width: calc(100% - 55%);
-            overflow-wrap: break-word;
-        }
-        &--recipient span {
-            padding: 0.7rem;
+            flex-direction: column;
+            align-items: start;
+            margin-block: 2rem;
+            
+            &-content{
+                background-color: var(--color-secondary);
+                border-radius: 1rem;
+                padding: 1.2rem;
+                width: fit-content;
+            }
         }
     }
 }

--- a/src/Views/Private/Chat/components/Messages/Messages.scss
+++ b/src/Views/Private/Chat/components/Messages/Messages.scss
@@ -1,7 +1,30 @@
 .message{
     &__wrapper{
         &--sender{
-            color: red;
+            background-color: var(--color-primary);
+            border-radius: 1rem;
+            display: flex;
+            padding: 0.5rem;
+            margin: 2.5rem 1.5rem 2.5rem auto;
+            flex-direction: row-reverse;
+            max-width: calc(100% - 55%);
+            overflow-wrap: break-word;
+        }
+        &--sender span {
+            padding: 0.7rem;
+        }
+
+        &--recipient{
+            background-color: var(--color-secondary);
+            border-radius: 1rem;
+            display: flex;
+            padding: 0.5rem;
+            margin: 2.5rem auto 2.5rem 1.5rem;
+            max-width: calc(100% - 55%);
+            overflow-wrap: break-word;
+        }
+        &--recipient span {
+            padding: 0.7rem;
         }
     }
 }

--- a/src/Views/Private/Chat/components/Messages/Messages.vue
+++ b/src/Views/Private/Chat/components/Messages/Messages.vue
@@ -5,13 +5,22 @@
 			{ 'message__wrapper--recipient': !isSender },
 		]"
 	>
-		<span>{{ message.content }}</span>
+		<div
+			:class="[
+				{ 'message__wrapper--sender-content': isSender },
+				{ 'message__wrapper--recipient-content': !isSender },
+			]"
+		>
+			<span>{{ message.content }}</span>
+		</div>
+		<span>{{ date }}</span>
 	</div>
 </template>
 
 <script lang="ts">
 import { defineComponent, PropType } from 'vue'
 import { IMessage } from '@/models/Message.model'
+import { getFormatedDate } from '@/helpers/date'
 
 export default defineComponent({
 	name: 'Messages',
@@ -28,6 +37,9 @@ export default defineComponent({
 			} else {
 				return false
 			}
+		},
+		date() {
+			return getFormatedDate(this.message.sendAt)
 		},
 	},
 })

--- a/src/Views/Private/Chat/components/Messages/Messages.vue
+++ b/src/Views/Private/Chat/components/Messages/Messages.vue
@@ -1,5 +1,10 @@
 <template>
-	<div :class="[{ 'message__wrapper--sender': isSender }]">
+	<div
+		:class="[
+			{ 'message__wrapper--sender': isSender },
+			{ 'message__wrapper--recipient': !isSender },
+		]"
+	>
 		<span>{{ message.content }}</span>
 	</div>
 </template>
@@ -18,7 +23,11 @@ export default defineComponent({
 	},
 	computed: {
 		isSender() {
-			return this.message.sender === 13
+			if (this.message.sender === 13) {
+				return true
+			} else {
+				return false
+			}
 		},
 	},
 })

--- a/src/helpers/date/index.ts
+++ b/src/helpers/date/index.ts
@@ -1,0 +1,14 @@
+export function getFormatedDate(date: Date) {
+
+	const today = new Date()
+    
+	if (date.getDate() < today.getDate()) {
+		return date.toLocaleDateString('pt-BR', { 
+			timeZone: 'America/Sao_Paulo'
+		})
+	}
+
+	return date.toLocaleTimeString('pt-BR', { 
+		timeZone: 'America/Sao_Paulo'
+	}).replace(/(.*)\D\d+/, '$1')
+}


### PR DESCRIPTION
Firstly, added a conditional return to the Messages component so the class will be based on the return of the computed function. Thereby, changed the style inside Messages.scss to both the sender and recipient messages. Althought the general style is working pretty well, I stumbled on a problem: How can we generate the box size of the message in a way that it is both responsive to the text size but also to the limit imposed by overflow-wrap.
I might be wrong about it, but here's what I suggest: What if, instead of sizing the context box utilizing the "&--sender" wrapper in general, why don't we add all the syles based on the "&--sender span" wrapper?